### PR TITLE
Rezilion - pillow:8.1.0 -> 9.2.0 - webgoat

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pillow == 8.1.0
+pillow == 9.2.0
 pycrypto == 2.6.1


### PR DESCRIPTION
![alt text](https://rezilion-ci-us-storage.s3.amazonaws.com/media/RezilionLogo.png)

Resolves #60

This merge request fixes package **pillow:8.1.0 -> pillow:9.2.0**

