### PR TITLE
Rezilion - pip:9.0.1 -> 19.2 - main

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 numpy == 1.18.0
 pandas == 1.0.3
-pip == 9.0.1
+pip == 19.2
 pillow == 8.1.0
 argparse == 1.2.1
 blackduck == 1.0.5
-certifi == 2021.10.8
+certifi == 2022.12.7
 cryptography == 2.1.4
 dataclasses == 0.8
 enum34 == 1.1.6
@@ -19,5 +19,5 @@ requests == 2.27.1
 secretstorage == 2.3.1
 setuptools == 39.0.1
 six === 1.11.0
-wheel == 0.30.0
+wheel == 0.38.1
 wsgiref == 0.1.2


### PR DESCRIPTION
![alt text](https://rezilion-ci-us-storage.s3.amazonaws.com/media/RezilionLogo.png)

Resolves #93

This merge request fixes package **pip:9.0.1 -> pip:19.2**

